### PR TITLE
Remove the smoke test commenting step

### DIFF
--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -140,21 +140,6 @@ jobs:
       - if: always()
         run: |
           kubectl logs --tail=20 --selector app.kubernetes.io/name=$LLAMA_HELM_RELEASE_NAME -n $HELM_NAMESPACE
-      - name: Comment the Joke
-        uses: actions/github-script@v6
-        # Note, issue and PR are the same thing in GitHub's eyes
-        # See https://stackoverflow.com/questions/58066966/commenting-a-pull-request-in-a-github-action
-        with:
-          script: |
-            const REPLY = process.env.REPLY
-            if (REPLY) {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `🤖: ${REPLY}`
-              })
-            }
   starcoder-smoke-test:
     runs-on: ubuntu-latest
     needs: build-image


### PR DESCRIPTION
As for some PR authors missing the permission, the CI might fail, for example dependabot. See https://github.com/chenhunghan/ialacol/pull/36