### PR TITLE
Add rust toolchain to fix docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM python:3.11-slim
 WORKDIR /app
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 COPY . .

--- a/Dockerfile.cuda11
+++ b/Dockerfile.cuda11
@@ -2,8 +2,10 @@
 
 # 11.7.1 https://github.com/ggerganov/llama.cpp/blob/master/.devops/main-cuda.Dockerfile
 FROM nvidia/cuda:11.7.1-base-ubuntu22.04
-RUN apt-get update && apt-get install -y -q python3 python3-pip
+RUN apt-get update && apt-get install -y -q python3 python3-pip curl
 WORKDIR /app
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 # https://github.com/marella/ctransformers#cuda

--- a/Dockerfile.cuda12
+++ b/Dockerfile.cuda12
@@ -1,8 +1,10 @@
 # syntax=docker/dockerfile:1
 
 FROM nvidia/cuda:12.2.0-base-ubuntu22.04
-RUN apt-get update && apt-get install -y -q python3 python3-pip
+RUN apt-get update && apt-get install -y -q python3 python3-pip curl
 WORKDIR /app
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 # https://github.com/marella/ctransformers#cuda

--- a/Dockerfile.gptq
+++ b/Dockerfile.gptq
@@ -2,9 +2,11 @@
 
 FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends g++ python3-dev python3-pip \
+    && apt-get install -y --no-install-recommends g++ python3-dev python3-pip curl \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 # Fixes exllama/cuda_ext.py:82: UserWarning: Failed to initialize NumPy: No module named 'numpy'

--- a/Dockerfile.metal
+++ b/Dockerfile.metal
@@ -3,6 +3,8 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt requirements.txt
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN pip3 install -r requirements.txt
 # https://github.com/marella/ctransformers#metal
 RUN CT_METAL=1 pip3 install ctransformers --no-binary ctransformers


### PR DESCRIPTION
Fixes
```
#21 [linux/arm64 5/8] RUN pip3 install -r requirements.txt
#21 21.45   Installing build dependencies: finished with status 'done'
#21 21.47   Getting requirements to build wheel: started
#21 21.99   Getting requirements to build wheel: finished with status 'done'
#21 22.00   Preparing metadata (pyproject.toml): started
#21 22.53   Preparing metadata (pyproject.toml): finished with status 'error'
#21 22.58   error: subprocess-exited-with-error
#21 22.58   
#21 22.58   × Preparing metadata (pyproject.toml) did not run successfully.
#21 22.58   │ exit code: 1
#21 22.58   ╰─> [6 lines of output]
#21 22.58       
#21 22.58       Cargo, the Rust package manager, is not installed or is not on PATH.
#21 22.58       This package requires Rust and Cargo to compile extensions. Install it through
#21 22.58       the system's package manager or via https://rustup.rs/
#21 22.58       
#21 22.58       Checking for Rust toolchain....
#21 22.58       [end of output]
#21 22.58   
#21 22.58   note: This error originates from a subprocess, and is likely not a problem with pip.
#21 22.59 error: metadata-generation-failed
#21 22.59 
#21 22.59 × Encountered error while generating package metadata.
#21 22.59 ╰─> See above for output.
#21 22.59 
#21 22.59 note: This is an issue with the package mentioned above, not pip.
#21 22.59 hint: See above for details.
#21 ERROR: process "/bin/sh -c pip3 install -r requirements.txt" did not complete successfully: exit code: 1
```