### PR TITLE
added-annotations-to-service-template

### DIFF
--- a/charts/ialacol/Chart.yaml
+++ b/charts/ialacol/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.13.0
 description: A Helm chart for ialacol
 name: ialacol
 type: application
-version: 0.13.0
+version: 0.14.0

--- a/charts/ialacol/templates/service.yaml
+++ b/charts/ialacol/templates/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.service.annotations }}
+  annotations: {{ .Values.service.annotations }}
+  {{- end }}
 spec:
   selector:
     app.kubernetes.io/instance: {{ .Chart.Name }}


### PR DESCRIPTION
Hi, annotations are required on a service when for instance using load balancers in an Azure managed cluster so this change is required to use the helm chart successfully in Azure with this functionality