### PR TITLE
Fix/add annotations to service template

### DIFF
--- a/charts/ialacol/Chart.yaml
+++ b/charts/ialacol/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.13.0
 description: A Helm chart for ialacol
 name: ialacol
 type: application
-version: 0.13.0
+version: 0.14.0

--- a/charts/ialacol/Chart.yaml
+++ b/charts/ialacol/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.13.0
 description: A Helm chart for ialacol
 name: ialacol
 type: application
-version: 0.14.0
+version: 0.15.0

--- a/charts/ialacol/templates/service.yaml
+++ b/charts/ialacol/templates/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.service.annotations }}
+  annotations: {{ .Values.service.annotations }}
+  {{- end }}
 spec:
   selector:
     app.kubernetes.io/instance: {{ .Chart.Name }}

--- a/charts/ialacol/templates/service.yaml
+++ b/charts/ialacol/templates/service.yaml
@@ -3,8 +3,9 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.service.annotations }}
-  annotations: {{ .Values.service.annotations }}
+  {{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
   {{- end }}
 spec:
   selector:


### PR DESCRIPTION
Apologies but my previous iteration broke the chart as it was attempting to insert the entire annotations map directly into the template. This version has been templated and tested and working as expected.